### PR TITLE
Support multiple manifestfile

### DIFF
--- a/DepotDownloader/ContentDownloader.cs
+++ b/DepotDownloader/ContentDownloader.cs
@@ -743,7 +743,7 @@ namespace DepotDownloader
             if (Config.UseManifestFile)
             {
                 lastManifestId = depot.ManifestId;
-                oldManifest = DepotManifest.LoadFromFile(Config.ManifestFile);
+                oldManifest = DepotManifest.LoadFromFile(Config.ManifestFile[depot.DepotId]);
                 if (oldManifest.FilenamesEncrypted)
                 {
                     if (!oldManifest.DecryptFilenames(depot.DepotKey))

--- a/DepotDownloader/DownloadConfig.cs
+++ b/DepotDownloader/DownloadConfig.cs
@@ -34,6 +34,6 @@ namespace DepotDownloader
         public bool SkipAppConfirmation { get; set; }
 
         public bool UseManifestFile { get; set; }
-        public string ManifestFile { get; set; }
+        public Dictionary<uint, string> ManifestFile { get; set; }
     }
 }

--- a/DepotDownloader/Program.cs
+++ b/DepotDownloader/Program.cs
@@ -190,7 +190,17 @@ namespace DepotDownloader
             ContentDownloader.Config.MaxDownloads = GetParameter(args, "-max-downloads", 8);
             ContentDownloader.Config.LoginID = HasParameter(args, "-loginid") ? GetParameter<uint>(args, "-loginid") : null;
             ContentDownloader.Config.UseManifestFile = HasParameter(args, "-manifestfile");
-            ContentDownloader.Config.ManifestFile = GetParameter<string>(args, "-manifestfile");
+            if (ContentDownloader.Config.UseManifestFile)
+            {
+                var depotIdList = GetParameterList<uint>(args, "-depot");
+                var manifestfiles = GetParameterList<string>(args, "-manifestfile");
+                if (depotIdList.Count != manifestfiles.Count)
+                {
+                    Console.WriteLine("Error: -depot count not equal -manifestfile count!");
+                    return 1;
+                }
+                ContentDownloader.Config.ManifestFile = depotIdList.Zip(manifestfiles).ToDictionary(x => x.First, x => x.Second);
+            }
 
             #endregion
 


### PR DESCRIPTION
example: DepotDownloaderMod.exe -app 100 -depot 101 102 -manifest 1111 2222 -depotkeys keys.txt -manifestfile 101_1111.manifest 102_2222.manifest -dir 100
It will download multiple depots (may be game + dlc) together to one directory.
By the way, I love Man Sui, too.